### PR TITLE
Add audio autoplay example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Backup files
+*~
+
+# Misc build artifacts
+build/
+dist/
+
+# Node modules
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # weezerd
+
+This project contains a simple example web page that plays an audio file automatically.
+
+## Serving the site
+
+You can serve the static files using Python's built-in HTTP server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000` in your browser to see the page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Audio Autoplay</title>
+</head>
+<body>
+    <audio controls autoplay loop>
+        <source src="static/audio.mp3" type="audio/mpeg">
+        Your browser does not support the audio element.
+    </audio>
+</body>
+</html>

--- a/static/audio.mp3
+++ b/static/audio.mp3
@@ -1,0 +1,1 @@
+This is a placeholder audio file for demonstration purposes.


### PR DESCRIPTION
## Summary
- build an autoplaying audio page using `index.html`
- add placeholder `audio.mp3`
- update `README` with instructions to run the site
- ignore typical build artifacts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843cae660e4832aa31ec3b10de21b85